### PR TITLE
Corrección de validación en el campo de apellido y número de teléfono

### DIFF
--- a/src/components/Register.tsx
+++ b/src/components/Register.tsx
@@ -24,9 +24,24 @@ const isAdult = (birthday: string): boolean => {
 
 const registerSchema = z
   .object({
-    name: z.string().min(2, "El nombre debe tener al menos 2 caracteres"),
-    surname: z.string().min(2, "El apellido debe tener al menos 2 caracteres"),
-    phone: z.string().min(8, "El teléfono debe tener al menos 8 caracteres"),
+    name: z
+      .string()
+      .min(2, "El nombre debe tener al menos 2 caracteres")
+      .regex(
+        /^[a-zA-ZáéíóúÁÉÍÓÚñÑ\s]+$/,
+        "El nombre solo puede contener letras y espacios",
+      ),
+    surname: z
+      .string()
+      .min(2, "El apellido debe tener al menos 2 caracteres")
+      .regex(
+        /^[a-zA-ZáéíóúÁÉÍÓÚñÑ\s]+$/,
+        "El apellido solo puede contener letras y espacios",
+      ),
+    phone: z
+      .string()
+      .min(8, "El teléfono debe tener al menos 8 caracteres")
+      .regex(/^\d+$/, "El teléfono solo puede contener números"),
     email: z.string().email("Email inválido"),
     password: z
       .string()


### PR DESCRIPTION
### Bugs corregidos:

**Validación de apellido:**

Se corrigió un error que permitía ingresar números en el campo "apellido". Ahora, el campo acepta únicamente caracteres alfabéticos.

**Validación de número de teléfono:**

Se corrigió un error que permitía ingresar letras en el campo "número de teléfono". Ahora, el campo acepta únicamente caracteres numéricos y está correctamente validado.