### PR TITLE
Fix/change donation creation to send account number + details

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -26,7 +26,7 @@ export const Footer: React.FC = () => {
             alt="logo"
             width={285}
             height={65}
-            className="pb-5"
+            className="pb-5 drop-shadow-logo"
           />
         </button>
         <div className="flex justify-between">

--- a/src/components/modal/DonateModal.tsx
+++ b/src/components/modal/DonateModal.tsx
@@ -36,9 +36,9 @@ export const DonateModal: React.FC<{
     setErrorMessage(null);
 
     const result = await donationService.createDonation(
-      receiver,
-      isAnonymousDonation,
       numericAmount,
+      parseInt(receiver),
+      isAnonymousDonation,
     );
 
     if (result.success) {
@@ -61,7 +61,7 @@ export const DonateModal: React.FC<{
       <LoadingContent
         title="Procesando la solicitud..."
         sender="Mi cuenta nativo"
-        receiver={receiver || ""}
+        receiver={receiver?.toString() || ""}
       />
     );
   } else if (isSuccess === true) {
@@ -70,7 +70,7 @@ export const DonateModal: React.FC<{
         <SuccessContent
           title="¡Solicitud de donación realizada!"
           sender="Mi cuenta nativo"
-          receiver={receiver || ""}
+          receiver={receiver?.toString() || ""}
           amount={amount.toString()}
         />
         <div className="mt-4 flex gap-4">
@@ -95,7 +95,7 @@ export const DonateModal: React.FC<{
         <ErrorContent
           error={errorMessage}
           sender="Mi cuenta nativo"
-          receiver={receiver || ""}
+          receiver={receiver?.toString() || ""}
           amount={amount.toString()}
         />
         <button
@@ -121,13 +121,19 @@ export const DonateModal: React.FC<{
             <input
               type="text"
               onChange={(e) => setReceiver(e.target.value)}
+              placeholder="Ingrese el número de cuenta destino"
               className="mt-2 h-10 w-full rounded-lg border border-[#C7C7C7] bg-transparent pl-4 text-sm placeholder-[#C7C7C7] shadow-md"
             />
           </div>
         </div>
-        {receiver == accountId && (
+        {receiver == user.dni && (
           <p className="-my-4 rounded-full bg-red-500 text-center text-white">
             No puede donar a su propia cuenta.
+          </p>
+        )}
+        {receiver && isNaN(parseInt(receiver)) && (
+          <p className="-my-4 rounded-full bg-red-500 text-center text-white">
+            El número de cuenta debe contener solo números
           </p>
         )}
         <div className="mb-2 flex gap-2 rounded-[20px] border border-secondary-green bg-light-grey p-3 drop-shadow-box">

--- a/src/services/donationService.ts
+++ b/src/services/donationService.ts
@@ -98,13 +98,12 @@ function normalizeDonation(donation: Donation, accountId: string) {
 }
 
 export async function createDonation(
-  accountIdBeneficiary: string,
-  anonymousDonation: boolean,
   amount: number,
+  numberAccountBeneficiary: number,
+  anonymousDonation: boolean,
 ) {
   try {
     const token = useUserStore.getState().token;
-    const accountId = useUserStore.getState().user?.accountId;
 
     const response = await fetch(`${api}/api/donaciones/crear-donacion`, {
       method: "POST",
@@ -114,8 +113,7 @@ export async function createDonation(
       },
       body: JSON.stringify({
         amount,
-        accountIdDonor: accountId,
-        accountIdBeneficiary,
+        numberAccountBeneficiary,
         anonymousDonation,
       }),
     });

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -21,6 +21,7 @@ export default {
       },
       dropShadow: {
         box: "2px 2px 2px rgba(0, 0, 0, 0.15)",
+        logo: "2px 2px 2px rgba(0, 0, 0, 0.25)",
       },
       fontFamily: {
         lato: ["Lato", "sans-serif"],


### PR DESCRIPTION
FIX: Donation creation now asks for accountNumber instead of accountId + details

Validations:
- If accountNumber contains any letter, it will show an error message indicating it can only have numbers (as we are using dni as accountNumber).
- If the accountNumber provided doesn't belong to any account, it will show an error indicating it.
- Donations amount needs to be > $100 and < than user available money. In case the amount provided is > than user available money it will show an error indicating it.
- User can not donate to themselves, if they write their own accountNumber it will show an error indicating so.